### PR TITLE
UI: Horizontal center for topMenu

### DIFF
--- a/sidebar.css
+++ b/sidebar.css
@@ -113,7 +113,9 @@ a.button.right {
 
 #topMenu {
     padding-bottom: 1em;
-    padding-left: 0.8em;
+    display: -webkit-box;
+    -webkit-box-orient: horizontal;
+    -webkit-box-pack: center;
 }
 
 #topMenu a {


### PR DESCRIPTION
As an alternative.

A strange thing, it does not work if use the `box` or the `-moz` prefix. Any thinking?